### PR TITLE
Allow use of credentials from AWS_PROFILE

### DIFF
--- a/lib/CloudWatchLogsStream.js
+++ b/lib/CloudWatchLogsStream.js
@@ -11,20 +11,18 @@ class CloudWatchLogsStream {
         pino = pinoLib({ level: opts.logLevel || 'silent', prettyPrint: true });
         pino.trace('Constructor Opts', opts);
 
-        if (!opts.file &&
-                !(opts.accessKeyId && opts.secretAccessKey && opts.region)) {
-            throw Error('AWS credential parameters are missing');
-        }
-
         if (opts.file) {
             AWS.config.loadFromPath(opts.file);
-        } else {
+        } else if(opts.accessKeyId && opts.secretAccessKey && opts.region) {
             AWS.config.update({
                 accessKeyId: opts.accessKeyId,
                 secretAccessKey: opts.secretAccessKey,
                 region: opts.region
             });
+        } else if(opts.region) {
+            AWS.config.update({ region: opts.region });
         }
+
         // config
         this.timeout = opts.timeout || 5000;
         this.batchSize = opts.batchSize || 1000;

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,11 @@ const optsBad = {
     batchSize: 1
 };
 
+const optsRegionOnly = {
+    logLevel: 'trace',
+    batchSize: 1,
+};
+
 describe('cloudwatchlogger - setup', function() {
     let CWLStub = null;
 
@@ -60,6 +65,19 @@ describe('cloudwatchlogger - setup', function() {
         done();
     });
 
+    it('should work if you specify AWS_PROFILE with proper keys', function(done) {
+        new Logger(optsRegionOnly).setupLogger('logName', 'logStream',
+            function(err, logger) {
+                assert.isNotOk(err);
+                assert.isOk(logger);
+                assert.equal(CWLStub._createGroup.calledOnce, true);
+                assert.equal(CWLStub._createStream.calledOnce, true);
+                assert.equal(CWLStub._resetSequenceToken.calledOnce, true);
+                assert.equal(CWLStub._putLogs.calledOnce, false);
+                done();
+            });
+    });
+
     it('should setup logger', function(done) {
         new Logger(opts).setupLogger('logName', 'logStream',
             function(err, logger) {
@@ -85,6 +103,7 @@ describe('cloudwatchlogger - setup', function() {
                 done();
             });
     });
+
     /* eslint-disable consistent-return */
     it('should throw Exception', function(done) {
 


### PR DESCRIPTION
This allows credentials to not need to be specified in your code.  If they are not specified, then the AWS SDK will use its default fallback to set the values, using `~/.aws/credentials` or lambda credentials when running as an AWS lambda, etc.